### PR TITLE
Adding a DTF coefficient set variant that is runtime configurable

### DIFF
--- a/include/zeval/zeval.hpp
+++ b/include/zeval/zeval.hpp
@@ -1,13 +1,32 @@
 /**
- * @defgroup   DTFEVAL dtfeval
+ * @file       zeval.hpp
  *
- * @brief      This file implements the Discrete Transfer Function (DTF)
- *             Evaluating utility class `zeval::DTF` that sets up the
- *             difference-equation form of a DTF given its numerator and
- *             denominator coefficients.
+ * @brief      This file implements the Z-domain Transfer Function evaluation 
+ *             utility library that handle the set up and handling of
+ *             difference-equation form of discretized TFs, simply requiring the
+ *             user to specify the numerator and denominator coefficients.
+ * 
+ * @copyright  Copyright 2021 Alex Skrynnyk. All rights reserved.
+ * 
+ * @license    This project is released under the MIT License.
  *
- * @author     Alex Skrynnyk
- * @date       2021
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 /* Includes ------------------------------------------------------------------*/
@@ -271,9 +290,9 @@ public:
 /**
  * @brief      This class implements the actual DTF in difference equation form
  *
- * @tparam     TAsPolicy    { description }
- * @tparam     TBsPolicy    { description }
- * @tparam     TTickPolicy  { description }
+ * @tparam     TAsPolicy    Policy for the As coefficient set
+ * @tparam     TBsPolicy    Policy for the Bs coefficient set
+ * @tparam     TTickPolicy  Policy for getting system tick time
  */
 template<class TAsPolicy, class TBsPolicy, class TTickPolicy>
 class DTF {
@@ -281,6 +300,7 @@ class DTF {
                   std::is_base_of<detail::cset_t, TBsPolicy>::value, 
                   "Not a `HeterogeneousCSet` nor a `HomogeneousCSet` policy");
 public:
+    // TODO: make type specified via class template
     using Ys_t = std::array<float, TAsPolicy::size>;
     using Us_t = std::array<float, TBsPolicy::size>;
     
@@ -337,21 +357,44 @@ public:
         return Y;
     }
 
-    constexpr float operator()() const {
+    /**
+     * @brief      Returns the latest evaluation value of the TF
+     *
+     * @return     latest computed output of this TF object
+     */
+    constexpr float value() const {
         return _Ys[0];
     }
 
-
+    /**
+     * @brief      Resets the state (history of inputs/outputs) of the TF
+     */
     constexpr void reset() {
         for (auto& y : _Ys) { y = 0; }
         for (auto& u : _Us) { u = 0; }
     }
 
+    /**
+     * @brief      Sets the initial conditions.
+     * 
+     * @note       Take care to set only when not actively evaluating new inputs
+     *
+     * @param[in]  Us    The new value of input records
+     * @param[in]  Ys    The new value of output records
+     */
     constexpr void setInitialConditions(const Us_t& Us, const Ys_t& Ys) {
         for (int i = 0; i < Us.size(); i++) { _Us[i] = Us[i]; }
         for (int i = 0; i < Ys.size(); i++) { _Ys[i] = Ys[i]; }
     }
 
+    /**
+     * @brief      Updates the coefficient values
+     * 
+     * @note       Currently also resets inteernal state to guanratee stability
+     *
+     * @param[in]  as    The new As coefficients
+     * @param[in]  bs    The new Bs coefficients
+     */
     constexpr void setCs(const TAsPolicy& as, const TBsPolicy& bs) {
         _As = as;
         _Bs = bs;
@@ -383,18 +426,18 @@ private:
 
 /* Public functions ----------------------------------------------------------*/
 /**
- * @brief      Makes a DTF
+ * @brief      Helper for creating a discrete TF object
  *
- * @param[in]  As           { parameter_description }
- * @param[in]  Bs           { parameter_description }
- * @param[in]  <unnamed>    { parameter_description }
- * @param[in]  Ts           { parameter_description }
+ * @param[in]  As           The A coefficients
+ * @param[in]  Bs           The B coefficients
+ * @param[in]  <unnamed>    System tick getter policy object
+ * @param[in]  Ts           Discretized TF sampling time
  *
- * @tparam     TAsPolicy          { description }
- * @tparam     TBsPolicy          { description }
- * @tparam     TTickPolicy  { description }
+ * @tparam     TAsPolicy    Policy for the As coefficient set
+ * @tparam     TBsPolicy    Policy for the Bs coefficient set
+ * @tparam     TTickPolicy  Policy for getting system tick time
  *
- * @return     { description_of_the_return_value }
+ * @return     The usable TF object
  */
 template<class TAsPolicy, class TBsPolicy, class TTickPolicy>
 constexpr auto makeDTF(const TAsPolicy& As, const TBsPolicy& Bs, TTickPolicy,
@@ -408,11 +451,11 @@ constexpr auto makeDTF(const TAsPolicy& As, const TBsPolicy& Bs, TTickPolicy,
 /**
  * @brief      Makes a DTF coefficient set with unique values
  *
- * @param[in]  cs    The create struct
+ * @param[in]  cs    The set of coefficient values
  *
- * @tparam     TCs   { description }
+ * @tparam     TCs   Type of the individual coefficients
  *
- * @return     { description_of_the_return_value }
+ * @return     A `HeterogeneousCSet` containing the specified coefs
  */
 template<class... TCs>
 constexpr auto makeCs(const TCs&... cs)
@@ -426,11 +469,11 @@ constexpr auto makeCs(const TCs&... cs)
 /**
  * @brief      Makes a DTF coefficient set composed of the same value
  *
- * @param[in]  cs    The coefficients
+ * @param[in]  cs    The set of coefficient values
  *
- * @tparam     TCs   { description }
+ * @tparam     TCs   Type of the individual coefficients
  *
- * @return     { description_of_the_return_value }
+ * @return     A `HomogeneousCSet` containing the specified coefs
  */
 template<class... TCs>
 constexpr auto makeHomogeonousCs(const TCs&... cs)
@@ -442,16 +485,6 @@ constexpr auto makeHomogeonousCs(const TCs&... cs)
 }
 
 namespace util {
-/**
- * @brief      Makes a moving average.
- *
- * @param[in]  <unnamed>  { parameter_description }
- *
- * @tparam     Tsize      { description }
- * @tparam     I          { description }
- *
- * @return     { description_of_the_return_value }
- */
 template<uint32_t Tsize, size_t ... I>
 constexpr auto makeMovingAvg(::zeval::detail::index_sequence<I ...>)
     -> decltype(makeHomogeonousCs((1.0f / Tsize * (I / I))...))
@@ -459,16 +492,6 @@ constexpr auto makeMovingAvg(::zeval::detail::index_sequence<I ...>)
     return makeHomogeonousCs(((void) I, (1.0f / Tsize))...);
 }
 
-/**
- * @brief      Makes a delay.
- *
- * @param[in]  <unnamed>  { parameter_description }
- *
- * @tparam     Tsize      { description }
- * @tparam     I          { description }
- *
- * @return     { description_of_the_return_value }
- */
 template<std::uint32_t Tsize, size_t ... I>
 constexpr auto makeDelay(::zeval::detail::index_sequence<I ...>)
     -> decltype(makeCs(((Tsize - I > 1) ? 0.0f : 1.0f)...))
@@ -477,15 +500,15 @@ constexpr auto makeDelay(::zeval::detail::index_sequence<I ...>)
 }
 
 /**
- * @brief      Makes a moving average (FIR) filter DTF
+ * @brief      Makes a moving average (FIR) low pass filter\
  *
- * @param[in]  p            { parameter_description }
- * @param[in]  Ts           { parameter_description }
+ * @param[in]  p            System tick getter policy object
+ * @param[in]  Ts           Discretized TF sampling time
  *
- * @tparam     Tsize        { description }
- * @tparam     TTickPolicy  { description }
+ * @tparam     Tsize        Size of the moving average window
+ * @tparam     TTickPolicy  Policy for getting system tick time
  *
- * @return     { description_of_the_return_value }
+ * @return     The usable TF object
  */
 template<uint32_t Tsize, class TTickPolicy>
 constexpr auto makeMovingAvg(TTickPolicy p, uint16_t Ts)
@@ -498,16 +521,15 @@ constexpr auto makeMovingAvg(TTickPolicy p, uint16_t Ts)
 }
 
 /**
- * @brief      Makes a single pole IIR filter DTF
+ * @brief      Makes a simple single pole IIR low pass filter
  *
- * @param[in]  alpha        The alpha
- * @param[in]  p            { parameter_description }
- * @param[in]  Ts           { parameter_description }
+ * @param[in]  alpha        The alpha value ("smoothing factor")
+ * @param[in]  p            System tick getter policy object
+ * @param[in]  Ts           Discretized TF sampling time
  *
- * @tparam     Tsize        { description }
- * @tparam     TTickPolicy  { description }
+ * @tparam     TTickPolicy  Policy for getting system tick time
  *
- * @return     { description_of_the_return_value }
+ * @return     The usable TF object
  */
 template<class TTickPolicy>
 constexpr auto makeSinglePoleIIR(float alpha, TTickPolicy p, uint16_t Ts)
@@ -517,14 +539,14 @@ constexpr auto makeSinglePoleIIR(float alpha, TTickPolicy p, uint16_t Ts)
 }
 
 /**
- * @brief      Makes a differentiator.
+ * @brief      Makes a discrete differentiator
  *
- * @param[in]  p            { parameter_description }
- * @param[in]  Ts           { parameter_description }
+ * @param[in]  p            System tick getter policy object
+ * @param[in]  Ts           Discretized TF sampling time
  *
- * @tparam     TTickPolicy  { description }
+ * @tparam     TTickPolicy  Policy for getting system tick time
  *
- * @return     { description_of_the_return_value }
+ * @return     The usable TF object
  */
 template<class TTickPolicy>
 constexpr auto makeDifferentiator(TTickPolicy p, uint16_t Ts)
@@ -534,14 +556,14 @@ constexpr auto makeDifferentiator(TTickPolicy p, uint16_t Ts)
 }
 
 /**
- * @brief      Makes an integrator.
+ * @brief      Makes a discrete rectangular integrator.
  *
- * @param[in]  p            { parameter_description }
- * @param[in]  Ts           { parameter_description }
+ * @param[in]  p            System tick getter policy object
+ * @param[in]  Ts           Discretized TF sampling time
  *
- * @tparam     TTickPolicy  { description }
+ * @tparam     TTickPolicy  Policy for getting system tick time
  *
- * @return     { description_of_the_return_value }
+ * @return     The usable TF object
  */
 template<class TTickPolicy>
 constexpr auto makeIntegrator(TTickPolicy p, uint16_t Ts)
@@ -552,15 +574,15 @@ constexpr auto makeIntegrator(TTickPolicy p, uint16_t Ts)
 }
 
 /**
- * @brief      Makes a moving average (FIR) filter DTF
+ * @brief      Makes a delay line filter
  *
- * @param[in]  p            { parameter_description }
- * @param[in]  Ts           { parameter_description }
+ * @param[in]  p            System tick getter policy object
+ * @param[in]  Ts           Discretized TF sampling time
  *
- * @tparam     Tsize        { description }
- * @tparam     TickPolicy  { description }
+ * @tparam     Tsize        Length of the delay
+ * @tparam     TTickPolicy  Policy for getting system tick time
  *
- * @return     { description_of_the_return_value }
+ * @return     The usable TF object
  */
 template<std::uint32_t Tsize, class TTickPolicy>
 constexpr auto makeDelay(TTickPolicy p, uint16_t Ts)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,11 +1,249 @@
 #include <zeval/zeval.hpp>
 #include <catch2/catch_all.hpp>
+#include <cmath>
 
-TEST_CASE("test_makeCs")
+//==============================================================================
+// Coefficient Set Tests
+//==============================================================================
+
+template<std::size_t NumCoefs>
+struct CsetTestCase {
+    std::array<float, NumCoefs> ins;
+    float out;
+};
+
+
+TEST_CASE("Heterogeneous CSet")
 {
-    auto num = zeval::makeCs(4.0f, 2.2f);
-    REQUIRE(num.size == 2);
+    SECTION("Single C")
+    {
+        constexpr std::size_t k_num_coefs = 1;
+        auto num     = zeval::makeCs(4.0f);
+        using test_t = CsetTestCase<k_num_coefs>;
+        auto cases   = std::array<test_t, 4>{
+            test_t{ {0}, 0.0f },
+            test_t{ {1}, 4.0f },
+            test_t{ {2}, 8.0f }
+        };
+
+        REQUIRE(num.size == k_num_coefs);
+
+        for (auto& c : cases) {
+            REQUIRE(num(c.ins, zeval::detail::pos_t{}) == c.out);
+            REQUIRE(num(c.ins, zeval::detail::neg_t{}) == -1.0 * c.out);
+        }
+    }
+
+    SECTION("Multiple Cs")
+    {
+        constexpr std::size_t k_num_coefs = 2;
+        auto num     = zeval::makeCs(4.0f, 2.5f);
+        using test_t = CsetTestCase<k_num_coefs>;
+        auto cases   = std::array<test_t, 4>{
+            test_t{ {1, 0}, 4.0f },
+            test_t{ {0, 1}, 2.5f },
+            test_t{ {1, 1}, 6.5f },
+            test_t{ {2, 3}, 15.5f }
+        };
+
+        REQUIRE(num.size == k_num_coefs);
+
+        for (auto& c : cases) {
+            REQUIRE(num(c.ins, zeval::detail::pos_t{}) == c.out);
+            REQUIRE(num(c.ins, zeval::detail::neg_t{}) == -1.0 * c.out);
+        }
+    }
 }
+
+
+TEST_CASE("Homogeneous CSet")
+{
+    SECTION("Single C")
+    {
+        constexpr std::size_t k_num_coefs = 1;
+        auto num     = zeval::makeHomogeneousCs(4.0f);
+        using test_t = CsetTestCase<k_num_coefs>;
+        auto cases   = std::array<test_t, 4>{
+            test_t{ {0}, 0.0f },
+            test_t{ {1}, 4.0f },
+            test_t{ {2}, 8.0f }
+        };
+
+        REQUIRE(num._c == 4.0f);
+        REQUIRE(num.size == k_num_coefs);
+
+        for (auto& c : cases) {
+            REQUIRE(num(c.ins, zeval::detail::pos_t{}) == c.out);
+            REQUIRE(num(c.ins, zeval::detail::neg_t{}) == -1.0 * c.out);
+        }
+    }
+
+    SECTION("Multiple Cs")
+    {
+        constexpr std::size_t k_num_coefs = 2;
+        auto num     = zeval::makeHomogeneousCs(4.0f, 4.0f);
+        using test_t = CsetTestCase<k_num_coefs>;
+        auto cases   = std::array<test_t, 4>{
+            test_t{ {1, 0}, 4.0f },
+            test_t{ {0, 1}, 4.0f },
+            test_t{ {1, 1}, 8.0f },
+            test_t{ {2, 3}, 20.0f }
+        };
+
+        REQUIRE(num._c == 4.0f);
+        REQUIRE(num.size == k_num_coefs);
+
+        for (auto& c : cases) {
+            REQUIRE(num(c.ins, zeval::detail::pos_t{}) == c.out);
+            REQUIRE(num(c.ins, zeval::detail::neg_t{}) == -1.0 * c.out);
+        }
+    }
+}
+
+//==============================================================================
+// Transfer Function Tests
+//==============================================================================
+
+struct MockTickPolicy {
+    static uint32_t getTick() { static int i = 0; return i++; }
+};
+
+struct TFTestCase {
+    float in;
+    float out;
+};
+
+/* Reference -- must be correct by inspection */
+class ReferenceImpl {
+public:
+    float a0 = 0, b0 = 0, b1 = 0;
+
+    float yk_1 = 0;
+    float uk_1 = 0;
+    bool is_n1 = true;
+
+    ReferenceImpl(float b0, float b1, float a0)
+        : a0{ a0 }
+        , b0{ b0 }
+        , b1{ b1 }
+    {}
+
+    float compute(float reading) {
+        float yk1 = 0;
+        float uk1 = 0;
+
+        if (is_n1) {
+            yk1 = 0;
+            uk1 = 0;
+            is_n1 = false;
+        } else {
+            yk1 = yk_1;
+            uk1 = uk_1;
+        }
+
+        float u = reading;
+        uk_1 = u;
+        float y = b0 * u + b1 * uk1 - a0 * yk1;
+        yk_1 = y;
+        return y;
+    }
+
+};
+
+
+bool equal_within_perc(float ref, float test, float percent = 0.1) {
+    return (std::fabs(ref - test) <= (ref * (percent / 100.0)));
+}
+
+
+TEST_CASE("DTF class")
+{
+    SECTION("Basic class operation")
+    {
+        constexpr std::size_t k_ts = 1;
+        auto num = zeval::makeCs(4.0f);
+        auto den = zeval::makeCs(1.0f);
+        auto Gz  = zeval::makeDTF(num, den, MockTickPolicy{}, k_ts);
+
+        REQUIRE(Gz.value() == 0.0f);
+        
+        (void) Gz(5);
+        (void) Gz(2);
+        REQUIRE(Gz.value() != 0.0f);
+        
+        Gz.reset();
+        REQUIRE(Gz.value() == 0.0f);
+    }
+
+    SECTION("Unity TF output")
+    {
+        constexpr std::size_t k_num_coefs = 1;
+        constexpr std::size_t k_ts = 1;
+        auto num     = zeval::makeCs(1.0f);
+        auto den     = zeval::makeCs(0.0f);
+        auto Gz      = zeval::makeDTF(num, den, MockTickPolicy{}, k_ts);
+        using test_t = TFTestCase;
+        auto cases   = std::array<test_t, 5>{
+            test_t{ 5.0f, 5.0f },
+            test_t{ 5.0f, 5.0f },
+            test_t{ 5.0f, 5.0f },
+            test_t{ 5.0f, 5.0f },
+            test_t{ 5.0f, 5.0f }
+        };
+
+        float out = 0.0f;
+        for (auto& c : cases) {
+            out = Gz(c.in);
+            CAPTURE(out, c.out);
+            REQUIRE(out == c.out);
+        }
+    }
+
+    constexpr auto Bs = std::array<float, 2>{ 0.038607f, -0.035720f };
+    constexpr auto As = std::array<float, 1>{ -0.996750f };
+
+    auto Gz_ref   = ReferenceImpl{ Bs[0], Bs[1],
+                                   As[0] };
+    auto Gz_zeval = zeval::makeDTF(zeval::makeCs(Bs[0], Bs[1]),
+                                   zeval::makeCs(As[0]),
+                                   MockTickPolicy{}, 
+                                   1);
+
+    SECTION("Reference vs Zeval: Internal State")
+    {
+        constexpr std::size_t k_num_iters = 20;
+        constexpr float       input       = 15;
+
+        float output_ref = 0;
+        float output_zeval = 0;
+        for (int i = 0; i < k_num_iters; i++) {
+            output_ref   = Gz_ref.compute(input);
+            output_zeval = Gz_zeval(input);
+            // CAPTURE(output_ref, output_zeval);
+            REQUIRE(equal_within_perc(Gz_ref.yk_1, Gz_zeval._Ys[0]));
+            REQUIRE(equal_within_perc(Gz_ref.uk_1, Gz_zeval._Us[0]));
+            // CHECK(equal_within_perc(output_ref, output_zeval));
+        }
+    }
+
+    SECTION("Reference vs Zeval: Step Response")
+    {
+        constexpr std::size_t k_num_iters = 2000;
+        constexpr float       input       = 15;
+
+        float output_ref = 0;
+        float output_zeval = 0;
+        for (int i = 0; i < k_num_iters; i++) {
+            output_ref   = Gz_ref.compute(input);
+            output_zeval = Gz_zeval(input);
+            CAPTURE(output_ref, output_zeval);
+            REQUIRE(equal_within_perc(output_ref, output_zeval));
+        }
+    }
+}
+
+
+//==============================================================================
 
 int main( int argc, char* argv[] )
 {


### PR DESCRIPTION
This extends the previously compile-time chaining of coefficients with corresponding U/Y samples, using a template metaprogrammed `DTF` coefficient set, with a more straightforward runtime chaining, using vanilla for loops. This flavor of coefficient set has the ability to be modified at runtime, whereas with the compile-time equivalent you had to swap in a different `DTF` object that was instantiated at compile-time if you want to use different coefficients. For example, this allows you to create variable or gain-scheduled `DTF` objects